### PR TITLE
dcvmu: add include for system types

### DIFF
--- a/dcvmu.hpp
+++ b/dcvmu.hpp
@@ -1,5 +1,7 @@
 // $Id$
 
+#include <sys/types.h>
+
 #define ssize_t unsigned int
 #define uint8 unsigned char
 #define uint16 unsigned short


### PR DESCRIPTION
This fixes the build in clang by ensuring the system `ssize_t` type is defined first.